### PR TITLE
 template: Update to use crates.io versions of packages and use 2018 idioms 

### DIFF
--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 serde = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 serde_derive = "=1.0.89"
-hdk = { git = "https://github.com/holochain/holochain-rust", tag = "v{{ version }}" }
-holochain_wasm_utils = { git = "https://github.com/holochain/holochain-rust", tag = "v{{ version }}" }
+hdk = "={{ version }}"
+holochain_wasm_utils = "={{ version }}"
 holochain_json_derive = "=0.0.1-alpha2"
 
 [lib]

--- a/code/src/lib.rs
+++ b/code/src/lib.rs
@@ -1,37 +1,21 @@
-#[macro_use]
-extern crate hdk;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-#[macro_use]
-extern crate holochain_json_derive;
-
 use hdk::{
+    define_zome, entry,
     entry_definition::ValidatingEntryType,
     error::ZomeApiResult,
+    holochain_core_types::{dna::entry_types::Sharing, entry::Entry},
+    holochain_json_api::{error::JsonError, json::JsonString},
+    holochain_persistence_api::cas::content::Address,
+    load_json,
 };
-use hdk::holochain_core_types::{
-    entry::Entry,
-    dna::entry_types::Sharing,
-};
-
-use hdk::holochain_persistence_api::{
-    cas::content::Address,
-};
-
-use hdk::holochain_json_api::{
-    error::JsonError,
-    json::JsonString,
-};
-
+use holochain_json_derive::DefaultJson;
+use serde_derive::{Deserialize, Serialize};
 
 // see https://docs.rs/hdk/{{ version }}/hdk/ for info on using the hdk library
 
 // This is a sample zome that defines an entry type "MyEntry" that can be committed to the
 // agent's chain via the exposed function create_my_entry
 
-#[derive(Serialize, Deserialize, Debug, DefaultJson,Clone)]
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
 pub struct MyEntry {
     content: String,
 }

--- a/code/src/lib.rs
+++ b/code/src/lib.rs
@@ -26,7 +26,7 @@ use hdk::holochain_json_api::{
 };
 
 
-// see https://developer.holochain.org/api/{{ version }}/hdk/ for info on using the hdk library
+// see https://docs.rs/hdk/{{ version }}/hdk/ for info on using the hdk library
 
 // This is a sample zome that defines an entry type "MyEntry" that can be committed to the
 // agent's chain via the exposed function create_my_entry


### PR DESCRIPTION
This improves the code generated by `hc generate` significantly. Notably, this is backwards incompatible with versions of `hc` earlier than `0.0.33-alpha5` because they weren't uploaded to crates.io. 

Changing the `hdk` docs link to use `docs.rs` also fixes it for recent versions. (e.g. Try going to https://developer.holochain.org/api/0.0.38-alpha14/hdk/, it will give Page Not Found)